### PR TITLE
Convert from Zephyr to C99 types

### DIFF
--- a/libmetal/lib/system/zephyr/time.c
+++ b/libmetal/lib/system/zephyr/time.c
@@ -12,7 +12,7 @@
 #include <metal/time.h>
 #include <sys_clock.h>
 
-extern volatile u64_t _sys_clock_tick_count;
+extern volatile uint64_t _sys_clock_tick_count;
 
 unsigned long long metal_get_timestamp(void)
 {


### PR DESCRIPTION
Convert to use C99 types as we intend to deprecate the zephyr
specific integer types.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>