### PR TITLE
cmake: set the policy CMP0077 to NEW

### DIFF
--- a/libmetal/CMakeLists.txt
+++ b/libmetal/CMakeLists.txt
@@ -3,6 +3,10 @@ if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif()
 
+if (POLICY CMP0077)
+  cmake_policy(SET CMP0077 NEW)
+endif()
+
 list (APPEND CMAKE_MODULE_PATH
       "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
       "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"


### PR DESCRIPTION
Fixes: #zephyr/issues/26142

This commit introduces CMP0077 and set the policy to NEW behavior.

Both OLD and NEW behavior will use the value defined earlier in the
CMake process, however the OLD behavior will also add an entry to the
CMakeCache.txt but ignore that value on sub-sequent invocations.
As this may lead to confusion on users looking into the CMakeCache.txt,
then the best is to not get such values into the cache, and thus use NEW
behavior.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>