### PR TITLE
zephyr: cache: Use new cache API

### DIFF
--- a/libmetal/lib/system/zephyr/cache.h
+++ b/libmetal/lib/system/zephyr/cache.h
@@ -25,12 +25,12 @@ extern "C" {
 
 static inline void __metal_cache_flush(void *addr, unsigned int len)
 {
-	sys_cache_data_range(addr, len, K_CACHE_WB);
+	sys_cache_data_flush_range(addr, len);
 }
 
 static inline void __metal_cache_invalidate(void *addr, unsigned int len)
 {
-	sys_cache_data_range(addr, len, K_CACHE_INVD);
+	sys_cache_data_invd_range(addr, len);
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Use the new cache API for the cache hooks.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>