### PR TITLE
Add support for Zephyr's POSIX architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,5 +10,13 @@ set(WITH_ZEPHYR_LIB 1)
 set(WITH_DOC OFF CACHE BOOL "" FORCE)
 set(WITH_DEFAULT_LOGGER OFF CACHE BOOL "" FORCE)
 
+if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "posix")
+	# When building Zephyr for the POSIX architecture
+	# CMAKE_SYSTEM_PROCESSOR is set to POSIX. We need
+	# to set it instead to "hosted" which is what the
+	# libmetal build specs for such a target.
+	set(CMAKE_SYSTEM_PROCESSOR "hosted")
+endif()
+
 add_subdirectory(${CONFIG_LIBMETAL_SRC_PATH} libmetal)
 endif()

--- a/libmetal/lib/processor/hosted/CMakeLists.txt
+++ b/libmetal/lib/processor/hosted/CMakeLists.txt
@@ -1,0 +1,2 @@
+collect (PROJECT_LIB_HEADERS atomic.h)
+collect (PROJECT_LIB_HEADERS cpu.h)

--- a/libmetal/lib/processor/hosted/atomic.h
+++ b/libmetal/lib/processor/hosted/atomic.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * @file	hosted/atomic.h
+ * @brief	Hosted environment atomic primitives for libmetal.
+ */
+
+#ifndef __METAL_HOSTED_ATOMIC__H__
+#define __METAL_HOSTED_ATOMIC__H__
+
+#endif /* __METAL_HOSTED_ATOMIC__H__ */

--- a/libmetal/lib/processor/hosted/cpu.h
+++ b/libmetal/lib/processor/hosted/cpu.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * @file	hosted/cpu.h
+ * @brief	Hosted environment CPU specific primitives
+ */
+
+#include <metal/sys.h>
+
+#ifndef __METAL_HOSTED_CPU__H__
+#define __METAL_HOSTED_CPU__H__
+
+static inline void metal_cpu_yield(void)
+{
+	metal_wait_usec(1);
+}
+
+#endif /* __METAL_HOSTED_CPU__H__ */

--- a/libmetal/lib/system/zephyr/sys.h
+++ b/libmetal/lib/system/zephyr/sys.h
@@ -17,6 +17,7 @@
 #define __METAL_ZEPHYR_SYS__H__
 
 #include <stdlib.h>
+#include <zephyr/kernel.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -38,6 +39,11 @@ struct metal_state {
 	/** Common (system independent) data. */
 	struct metal_common_state common;
 };
+
+static inline void metal_wait_usec(uint32_t usec_to_wait)
+{
+	k_busy_wait(usec_to_wait);
+}
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Zephyr's "POSIX architecture" is a test architecture which allows building the embedded SW with the Zephyr OS and HW models as a Linux executable.

When building for this target the Zephyr build
system will set the PROJECT_PROCESSOR as "posix".

We need to provide appropriate replacements
for the processor HAL for this "processor".
The "metal_cpu_yield()" call, which in other
architectures is handled as doing nothing, and therefore busy waiting, needs replacing with a call out to
Z_SPIN_DELAY(1)