### PR TITLE
Zephyr integration: Use K_HEAP_MEM_POOL_SIZE

### DIFF
--- a/libmetal/lib/system/zephyr/alloc.c
+++ b/libmetal/lib/system/zephyr/alloc.c
@@ -12,7 +12,7 @@
 #include <metal/alloc.h>
 #include <metal/compiler.h>
 
-#if (CONFIG_HEAP_MEM_POOL_SIZE <= 0)
+#if (K_HEAP_MEM_POOL_SIZE <= 0)
 
 void *metal_weak metal_zephyr_allocate_memory(unsigned int size)
 {
@@ -25,4 +25,4 @@ void metal_weak metal_zephyr_free_memory(void *ptr)
 	(void)ptr;
 }
 
-#endif /* CONFIG_HEAP_MEM_POOL_SIZE */
+#endif /* K_HEAP_MEM_POOL_SIZE */

--- a/libmetal/lib/system/zephyr/alloc.h
+++ b/libmetal/lib/system/zephyr/alloc.h
@@ -23,7 +23,7 @@
 extern "C" {
 #endif
 
-#if (CONFIG_HEAP_MEM_POOL_SIZE > 0)
+#if (K_HEAP_MEM_POOL_SIZE > 0)
 static inline void *__metal_allocate_memory(unsigned int size)
 {
 	return k_malloc(size);
@@ -47,7 +47,7 @@ static inline void __metal_free_memory(void *ptr)
 {
 	metal_zephyr_free_memory(ptr);
 }
-#endif /* CONFIG_HEAP_MEM_POOL_SIZE */
+#endif /* K_HEAP_MEM_POOL_SIZE */
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
This define should be used instead of the Kconfig option to determine if the k_malloc family of functions are available.