### PR TITLE
libmetal: update CMake minimum version to 3.20.0

### DIFF
--- a/libmetal/CMakeLists.txt
+++ b/libmetal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0.2)
+cmake_minimum_required (VERSION 3.20.0)
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif()


### PR DESCRIPTION
3.0.2 is very ancient. Align with the minimal version typically used elsewhere in Zephyr.