### PR TITLE
Zephyr integration: Change condition to override CMAKE_SYSTEM_PROCESSOR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,10 @@ set(WITH_ZEPHYR_LIB 1)
 set(WITH_DOC OFF CACHE BOOL "" FORCE)
 set(WITH_DEFAULT_LOGGER OFF CACHE BOOL "" FORCE)
 
-if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "posix")
-	# When building Zephyr for the POSIX architecture
-	# CMAKE_SYSTEM_PROCESSOR is set to POSIX. We need
-	# to set it instead to "hosted" which is what the
-	# libmetal build specs for such a target.
+if(CONFIG_ARCH_POSIX)
+	# When building Zephyr for the POSIX architecture,
+	# we need to set CMAKE_SYSTEM_PROCESSOR to "hosted" which is
+	# what the libmetal build expects for such a target.
 	set(CMAKE_SYSTEM_PROCESSOR "hosted")
 endif()
 


### PR DESCRIPTION
Instead of looking at the current value of CMAKE_SYSTEM_PROCESSOR (which may not be set to "posix" anymore),
let's look at the architecture kconfig option, which should be stable.

Note: Since the nrf5340 switched its default ipc backend, Zephyr's CI on the posix arch is much more limited.
tests/subsys/ipc/ipc_service_api/tests.ipc.ipc_service_api.static_vrings still covers opem-amp w libmetal for the nrf5340bsim/nrf5340/cpuapp, but this test, as it covers quite little, will not have problems even if CMAKE_SYSTEM_PROCESSOR is not properly set.
Nonetheless, I "verified" this patch with that test ensuring the right files keep being built, and that the test keeps on passing.

----

For background about why CMAKE_SYSTEM_PROCESSOR may change, see
* https://github.com/zephyrproject-rtos/zephyr/pull/116571
* https://github.com/zephyrproject-rtos/zephyr/pull/116660